### PR TITLE
Update grails-spring-security-saml to support grails 3.3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This plugin provides SAML 2.0 support for Grails 3 applications.  It was origina
 ### Plugin Compatibility with Grails
 Grails 3.0.x - Use Version 3.0.x of the plugin
 Grails 3.1.x - Use Version 3.1.x of the plugin
+Grails 3.3.x - Use Version 3.3.x of the plugin
 
 ### Installation
 **Maven**
@@ -13,7 +14,7 @@ Grails 3.1.x - Use Version 3.1.x of the plugin
 <dependency>
   <groupId>org.grails.plugins</groupId>
   <artifactId>spring-security-saml</artifactId>
-  <version>3.0.0</version>
+  <version>3.3.0</version>
   <type>pom</type>
 </dependency>
 ```
@@ -21,7 +22,7 @@ Grails 3.1.x - Use Version 3.1.x of the plugin
 **Gradle**
 
 ```gradle
-compile 'org.grails.plugins:spring-security-saml:3.0.0'
+compile 'org.grails.plugins:spring-security-saml:3.3.0'
 ```
 
 NOTE: you may have to add the following repositories
@@ -74,8 +75,8 @@ All of these properties can be put in either application.yml or application.groo
 **grails.plugins.springsecurity.saml**
 
 
-| Property | Syntax | Example Value | Description | 
-|--------|------|-------------|-----------| 
+| Property | Syntax | Example Value | Description |
+|--------|------|-------------|-----------|
 | active | boolean | true | States whether or not SAML is active |
 | afterLoginUrl | url string | '/' | Redirection Url in your application upon successful login from the IDP |
 | afterLogoutUrl | url string | '/' | Redirection Url in your application upon successful logout from the IDP |
@@ -277,7 +278,7 @@ assets {
 }
 ```
 
-application.groovy 
+application.groovy
 
 ```
 // Added by the Spring Security Core plugin:
@@ -413,4 +414,3 @@ grails:
                passwords: ping:'ping123'
                defaultKey: 'ping'
 ```
-

--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,10 @@ plugins {
     id "com.jfrog.artifactory" version "3.1.1"
 }
 
-version "3.1.0"
+version "3.3.0"
 group "org.grails.plugins"
 
-apply plugin: 'maven-publish'
+//apply plugin: 'maven-publish'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: "spring-boot"
@@ -32,8 +32,9 @@ apply plugin: "org.grails.grails-gsp"
 apply plugin: "com.jfrog.artifactory"
 apply plugin: "com.jfrog.bintray"
 apply plugin: "io.spring.dependency-management"
+apply plugin: "org.grails.grails-plugin-publish"
 // Used for publishing to central repository, remove if not needed
-apply from:'https://raw.githubusercontent.com/grails/grails-profile-repository/master/profiles/plugin/templates/grailsCentralPublishing.gradle'
+//apply from:'https://raw.githubusercontent.com/grails/grails-profile-repository/master/profiles/plugin/templates/grailsCentralPublishing.gradle'
 //apply from:'https://raw.githubusercontent.com/grails/grails-profile-repository/master/profiles/plugin/templates/bintrayPublishing.gradle'
 
 bintray {
@@ -94,6 +95,8 @@ dependencyManagement {
 }
 
 dependencies {
+    compile "org.grails:grails-core"
+
     provided 'org.springframework.boot:spring-boot-starter-logging'
     provided "org.springframework.boot:spring-boot-starter-actuator"
     provided "org.springframework.boot:spring-boot-autoconfigure"
@@ -108,7 +111,7 @@ dependencies {
 
     console "org.grails:grails-console"
 
-    compile 'org.grails.plugins:spring-security-core:3.1.1'
+    compile 'org.grails.plugins:spring-security-core:3.2.0.M1'
 
     compile("commons-httpclient:commons-httpclient:3.1") {
         exclude module: ['commons-codec', 'commons-logging', 'junit']

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ dependencies {
 
     console "org.grails:grails-console"
 
-    compile 'org.grails.plugins:spring-security-core:3.2.0.M1'
+    compile 'org.grails.plugins:spring-security-core:3.2.1'
 
     compile("commons-httpclient:commons-httpclient:3.1") {
         exclude module: ['commons-codec', 'commons-logging', 'junit']

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+grailsVersion=3.3.0
+gormVersion=6.1.6.RELEASE
+gradleWrapperVersion=3.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 20 08:36:38 EST 2017
+#Fri Nov 27 23:09:32 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-bin.zip

--- a/gradlew
+++ b/gradlew
@@ -42,11 +42,6 @@ case "`uname`" in
     ;;
 esac
 
-# For Cygwin, ensure paths are in UNIX format before anything is touched.
-if $cygwin ; then
-    [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
-fi
-
 # Attempt to set APP_HOME
 # Resolve links: $0 may be a link
 PRG="$0"
@@ -61,9 +56,9 @@ while [ -h "$PRG" ] ; do
     fi
 done
 SAVED="`pwd`"
-cd "`dirname \"$PRG\"`/" >&-
+cd "`dirname \"$PRG\"`/" >/dev/null
 APP_HOME="`pwd -P`"
-cd "$SAVED" >&-
+cd "$SAVED" >/dev/null
 
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
@@ -114,6 +109,7 @@ fi
 if $cygwin ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+    JAVACMD=`cygpath --unix "$JAVACMD"`
 
     # We build the pattern for arguments to be converted via cygpath
     ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -71,7 +71,8 @@ grails:
                   className: 'test.testRole'
                   nameField: 'auth'
             saml:
-                  userAttributeMappings: [username: 'username']
+                  userAttributeMappings:
+                      username: 'username'
                   active: true
                   afterLoginUrl: '/'
                   afterLogoutUrl: '/'
@@ -84,23 +85,25 @@ grails:
                   metadata:
                        defaultIdp: 'ping'
                        url: '/saml/metadata'
-                       providers: [ ping: 'security/idp-local.xml']
+                       providers:
+                           ping: 'security/idp-local.xml'
                        sp:
                            file: 'security/sp.xml'
-                           defaults: [
-                                local: true,
-                                alias: 'test',
-                                securityProfile: 'metaiop',
-                                signingKey: 'ping',
-                                encryptionKey: 'ping',
-                                tlsKey: 'ping',
-                                requireArtifactResolveSigned: false,
-                                requireLogoutRequestSigned: false,
-                                requireLogoutResponseSigned: false ]
+                           defaults:
+                                local: true
+                                alias: 'test'
+                                securityProfile: 'metaiop'
+                                signingKey: 'ping'
+                                encryptionKey: 'ping'
+                                tlsKey: 'ping'
+                                requireArtifactResolveSigned: false
+                                requireLogoutRequestSigned: false
+                                requireLogoutResponseSigned: false
                   keyManager:
                         storeFile: 'classpath:security/keystore.jks'
                         storePass: 'nalle123'
-                        passwords: [ ping: 'ping123' ]
+                        passwords:
+                            ping: 'ping123'
                         defaultKey: 'ping'
     views:
         default:

--- a/grails-app/init/org/grails/plugin/springsecurity/saml/Application.groovy
+++ b/grails-app/init/org/grails/plugin/springsecurity/saml/Application.groovy
@@ -9,6 +9,10 @@ import static grails.util.Metadata.getCurrent
 
 import static grails.util.Metadata.current as metaInfo
 
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.security.SecurityFilterAutoConfiguration
+
+@EnableAutoConfiguration(exclude = [SecurityFilterAutoConfiguration])
 class Application extends GrailsAutoConfiguration {
     static void main(String[] args) {
 

--- a/grails-app/services/org/grails/plugin/springsecurity/saml/SamlSecurityService.groovy
+++ b/grails-app/services/org/grails/plugin/springsecurity/saml/SamlSecurityService.groovy
@@ -47,4 +47,8 @@ class SamlSecurityService extends SpringSecurityService {
             }
         } else { return null}
     }
+
+    reactor.bus.Bus sendAndReceive(java.lang.Object obj, groovy.lang.Closure closure) {
+        return null
+    }
 }

--- a/grails-app/services/org/grails/plugin/springsecurity/saml/SpringSamlUserDetailsService.groovy
+++ b/grails-app/services/org/grails/plugin/springsecurity/saml/SpringSamlUserDetailsService.groovy
@@ -38,6 +38,7 @@ import grails.core.GrailsApplication
  * @author alvaro.sanchez
  */
 @Transactional
+@Slf4j('logger')
 class SpringSamlUserDetailsService extends GormUserDetailsService implements SAMLUserDetailsService {
 
     String authorityClassName
@@ -54,19 +55,19 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
 
 
     public Object loadUserBySAML(SAMLCredential credential) throws UsernameNotFoundException {
-        log.debug("Loading user - ${credential.toString()}")
+        logger.debug("Loading user - ${credential.toString()}")
         if (credential) {
             String username = getSamlUsername(credential)
-            log.debug("Username ${username}")
+            logger.debug("Username ${username}")
             if (!username) {
                 throw new UsernameNotFoundException("No username supplied in saml response.")
             }
 
             def user = generateSecurityUser(username)
-            log.debug("Generated User ${user.username}")
+            logger.debug("Generated User ${user.username}")
             user = mapAdditionalAttributes(credential, user)
             if (user) {
-                log.debug "Loading database roles for $username..."
+                logger.debug "Loading database roles for $username..."
                 def authorities = getAuthoritiesForUser(credential, username)
 
                 def grantedAuthorities = []
@@ -89,11 +90,11 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
                 else {
                     grantedAuthorities = authorities
                 }
-                log.debug("User Class ${user?.class}")
-                log.debug("User - username ${user?.username}")
-                log.debug("User - id ${user?.id}")
+                logger.debug("User Class ${user?.class}")
+                logger.debug("User - username ${user?.username}")
+                logger.debug("User - id ${user?.id}")
                 def userDetails = createUserDetails(user, grantedAuthorities)
-                log.debug("User Details ${userDetails.toString()}")
+                logger.debug("User Details ${userDetails.toString()}")
                 return userDetails
             } else {
                 throw new InstantiationException('could not instantiate new user')
@@ -102,10 +103,10 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
     }
 
     protected String getSamlUsername(credential) {
-        log.debug("getSamlUsername")
+        logger.debug("getSamlUsername")
         if (samlUserAttributeMappings?.username) {
             def value = credential.getAttributeAsString(samlUserAttributeMappings.username)
-            log.debug("Username getSamlUsername ${value}")
+            logger.debug("Username getSamlUsername ${value}")
             return value
         } else {
             // if no mapping provided for username attribute then assume it is the returned subject in the assertion
@@ -129,19 +130,19 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
         String[] samlGroups = credential.getAttributeAsStringArray(samlUserGroupAttribute)
 
         samlGroups.eachWithIndex { groupName, groupIdx ->
-            log.debug("Group Name From Saml ${groupName}")
+            logger.debug("Group Name From Saml ${groupName}")
             def role = samlUserGroupToRoleMapping?.find{ it?.value == groupName }?.key
             def authority
             if (role){
-                log.debug("Found Role")
+                logger.debug("Found Role")
                 authority = getRole(role)
             }
             if (authority) {
-                log.debug("Found Authority Adding it")
+                logger.debug("Found Authority Adding it")
                 authorities.add(new SimpleGrantedAuthority(authority."$authorityNameField"))
             }
         }
-        log.debug("Returning Authorities with  ${authorities?.size()} Authorities Added")
+        logger.debug("Returning Authorities with  ${authorities?.size()} Authorities Added")
         return authorities
     }
 
@@ -149,13 +150,13 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
     private Object generateSecurityUser(username) {
 
         if (userDomainClassName) {
-            log.debug("UserClassName ${userDomainClassName}")
+            logger.debug("UserClassName ${userDomainClassName}")
             Class<?> UserClass = grailsApplication.getClassForName(userDomainClassName)
-            log.debug("Artefact ${grailsApplication.getClassForName(userDomainClassName)}")
-            log.debug("Config ${grailsApplication.config.toString()}")
+            logger.debug("Artefact ${grailsApplication.getClassForName(userDomainClassName)}")
+            logger.debug("Config ${grailsApplication.config.toString()}")
 
                     //getClassForName(userDomainClassName)?.clazz
-            log.debug("UserClass ${UserClass}")
+            logger.debug("UserClass ${UserClass}")
             if (UserClass) {
                 def user = BeanUtils.instantiateClass(UserClass)
                 user.username = username
@@ -170,40 +171,40 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
     }
 
     private def saveUser(userClazz, user, authorities) {
-        log.debug("Saving User")
+        logger.debug("Saving User")
         if (userClazz && samlAutoCreateActive && samlAutoCreateKey && authorityNameField && authorityJoinClassName) {
 
             Map whereClause = [:]
             whereClause.put "$samlAutoCreateKey".toString(), user."$samlAutoCreateKey"
             Class<?> joinClass = grailsApplication.getDomainClass(authorityJoinClassName)?.clazz
-            log.debug("Before With Transaction")
+            logger.debug("Before With Transaction")
 
-                log.debug("Saving User")
+                logger.debug("Saving User")
                 def existingUser
                 userClazz.withTransaction {
                     existingUser = userClazz.findWhere(whereClause)
                 }
 
                 if (!existingUser) {
-                    log.debug("User Doesn't Exist.....save it")
+                    logger.debug("User Doesn't Exist.....save it")
                     userClazz.withTransaction {
                         user.save(flush:true)
                         //if (!user.save()) throw new UsernameNotFoundException("Could not save user ${user}");
                     }
 
                 } else {
-                    log.debug("User Exists.....update its properties")
+                    logger.debug("User Exists.....update its properties")
                     user = updateUserProperties(existingUser, user)
 
                     if (samlAutoAssignAuthorities) {
-                        log.debug("Remove all Authorities")
+                        logger.debug("Remove all Authorities")
                         joinClass.withTransaction {
                             joinClass.removeAll user
                         }
 
 
                     }
-                    log.debug("Now Save the User")
+                    logger.debug("Now Save the User")
                     userClazz.withTransaction {
                         user.save()
                     }
@@ -211,14 +212,14 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
                 }
 
                 if (samlAutoAssignAuthorities) {
-                    log.debug("go thru the list of authorities")
+                    logger.debug("go thru the list of authorities")
                     authorities.each { grantedAuthority ->
-                        log.debug("Working on Authority ${grantedAuthority}.${authorityNameField}")
+                        logger.debug("Working on Authority ${grantedAuthority}.${authorityNameField}")
                         def role = getRole(grantedAuthority."${authorityNameField}")
-                        log.debug("SAVING USER_ROLE - User name ${user.username}")
-                        log.debug("SAVING USER_ROLE - Role name ${role.authority}")
-                        log.debug("SAVING USER_ROLE - User Id ${user.id}")
-                        log.debug("SAVING USER_ROLE - Role Id ${role.id}")
+                        logger.debug("SAVING USER_ROLE - User name ${user.username}")
+                        logger.debug("SAVING USER_ROLE - Role name ${role.authority}")
+                        logger.debug("SAVING USER_ROLE - User Id ${user.id}")
+                        logger.debug("SAVING USER_ROLE - Role Id ${role.id}")
                         joinClass.withTransaction {
                             if (!joinClass.exists(user.id, role.id)){
                                 joinClass.create(user, role, true)
@@ -244,15 +245,15 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
 
     private Object getRole(String authority) {
         if (authority && authorityNameField && authorityClassName) {
-            log.debug("getRole - param -> ${authority}")
+            logger.debug("getRole - param -> ${authority}")
             Class<?> RoleClass = grailsApplication.getDomainClass(authorityClassName).clazz
             Map whereClause = [:]
             whereClause.put "$authorityNameField".toString(), authority
             if (RoleClass) {
                 RoleClass.withTransaction {
-                    log.debug("Where clause -> ${whereClause}")
+                    logger.debug("Where clause -> ${whereClause}")
                     def returnVal = RoleClass.findWhere(whereClause)
-                    log.debug("Return Value from getRole Class-> ${returnVal?.class}  Value -> ${returnVal}")
+                    logger.debug("Return Value from getRole Class-> ${returnVal?.class}  Value -> ${returnVal}")
                     returnVal
                 }
             } else {

--- a/grails-app/services/org/grails/plugin/springsecurity/saml/SpringSamlUserDetailsService.groovy
+++ b/grails-app/services/org/grails/plugin/springsecurity/saml/SpringSamlUserDetailsService.groovy
@@ -152,10 +152,10 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
             log.debug("UserClassName ${userDomainClassName}")
             Class<?> UserClass = grailsApplication.getClassForName(userDomainClassName)
             log.debug("Artefact ${grailsApplication.getClassForName(userDomainClassName)}")
-            println("Config ${grailsApplication.config.toString()}")
+            log.debug("Config ${grailsApplication.config.toString()}")
 
                     //getClassForName(userDomainClassName)?.clazz
-            println("UserClass ${UserClass}")
+            log.debug("UserClass ${UserClass}")
             if (UserClass) {
                 def user = BeanUtils.instantiateClass(UserClass)
                 user.username = username

--- a/grails-app/views/metadata/index.gsp
+++ b/grails-app/views/metadata/index.gsp
@@ -7,6 +7,10 @@
 <body>
 <div style="margin-left: 20px;">
 
+    <g:if test="${flash.message}">
+        <div class="message" role="status">${flash.message}</div>
+    </g:if>
+    
     <h1>Login/Logout</h1>
     <sec:ifLoggedIn>
         Welcome back, <sec:username/> | <sec:logoutLink local="true">Local logout</sec:logoutLink> | <sec:logoutLink>Global logout</sec:logoutLink>

--- a/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
+++ b/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
@@ -46,7 +46,7 @@ import org.apache.commons.httpclient.HttpClient
 class SpringSecuritySamlGrailsPlugin extends Plugin {
 
     // the version or versions of Grails the plugin is designed for
-    String grailsVersion = '3.0.0 > *'
+    String grailsVersion = '3.3.0 > *'
     String author = 'Jeff Wilson'
     String authorEmail = 'jeffwilson70@gmail.com'
     String title = 'Spring Security Saml2 Plugin'
@@ -59,7 +59,7 @@ class SpringSecuritySamlGrailsPlugin extends Plugin {
     def scm = [url: 'https://github.com/jeffwils/grails-spring-security-saml']
     def profiles = ['web']
 
-    def dependsOn = ['springSecurityCore' : '3.1.1 > *']
+    def dependsOn = ['springSecurityCore' : '3.2.0 > *']
     // resources that are excluded from plugin packaging
     def pluginExcludes = [
             'grails-app/domain/**',
@@ -95,7 +95,6 @@ class SpringSecuritySamlGrailsPlugin extends Plugin {
             context.'component-scan'('base-package': "org.springframework.security.saml")
 
             SpringSecurityUtils.registerProvider 'samlAuthenticationProvider'
-            SpringSecurityUtils.registerLogoutHandler 'successLogoutHandler'
             SpringSecurityUtils.registerLogoutHandler 'logoutHandler'
             SpringSecurityUtils.registerFilter 'samlEntryPoint', SecurityFilterPosition.SECURITY_CONTEXT_FILTER.order + 1
             SpringSecurityUtils.registerFilter 'metadataFilter', SecurityFilterPosition.SECURITY_CONTEXT_FILTER.order + 2
@@ -108,7 +107,7 @@ class SpringSecuritySamlGrailsPlugin extends Plugin {
                 defaultTargetUrl = conf.saml.afterLoginUrl
             }
 
-            successLogoutHandler(SimpleUrlLogoutSuccessHandler) {
+            logoutSuccessHandler(SimpleUrlLogoutSuccessHandler) {
                 defaultTargetUrl = conf.saml.afterLogoutUrl
             }
 
@@ -312,10 +311,10 @@ class SpringSecuritySamlGrailsPlugin extends Plugin {
             }
 
             samlLogoutFilter(SAMLLogoutFilter,
-                    ref('successLogoutHandler'), ref('logoutHandler'), ref('logoutHandler'))
+                    ref('logoutSuccessHandler'), ref('logoutHandler'), ref('logoutHandler'))
 
             samlLogoutProcessingFilter(SAMLLogoutProcessingFilter,
-                    ref('successLogoutHandler'), ref('logoutHandler'))
+                    ref('logoutSuccessHandler'), ref('logoutHandler'))
 
             webSSOprofileConsumer(WebSSOProfileConsumerImpl){
                 responseSkew = conf.saml.responseSkew


### PR DESCRIPTION
It is now finally possible to use grails-spring-security-saml with grails 3.3.x.

This pull request primarily updates the build.gradle and fixes the MetadataController and logoutSuccessHandler which broke because of API changes.

Note:
I haven't changed the configuration handling and I still feel it is incomplete.
Proper validation for the configuration values in applicaton.yml is missing.
The error messages are still messy if the application.yml doesn't exactly match what the plugin expects.
The configuration is easy to mess up and it is time consuming to figure out which of the dozens of settings was incorrect.