### PR TITLE
Specify project name in settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'spring-security-saml'


### PR DESCRIPTION
This way we don't have to clone into a 'spring-security-saml' directory
if we wish to build and install. As this way we overrid the project name
via `rootProject.name`.

Later if we want to change this to a multi-project build - i.e. with an
app to use for quick testing (like in spring security core) - then we
can change to something like:

    findProject(':plugin').name = 'spring-security-saml'

**If you're happy with all that, please merge.**