### PR TITLE
#24 - Exclude test domain classes from package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
     id "com.jfrog.artifactory" version "3.1.1"
 }
 
-version "3.3.0"
+version "3.3.1-SNAPSHOT"
 group "org.grails.plugins"
 
 //apply plugin: 'maven-publish'
@@ -153,4 +153,8 @@ dependencies {
 
 task wrapper(type: Wrapper) {
     gradleVersion = gradleWrapperVersion
+}
+
+jar {
+    exclude 'test/**'
 }

--- a/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
+++ b/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
@@ -62,7 +62,7 @@ class SpringSecuritySamlGrailsPlugin extends Plugin {
     def dependsOn = ['springSecurityCore' : '3.2.0 > *']
     // resources that are excluded from plugin packaging
     def pluginExcludes = [
-            'grails-app/domain/**',
+            'test/**',
             "grails-app/views/error.gsp",
             'docs/**',
             'scripts/PublishGithub.groovy'


### PR DESCRIPTION
Needed to use the new configuration and exclusion idiom to ensure that
the three test domain classes are not in the distributed JAR. This
involves an exclusion `SpringSecuritySamlGrailsPlugin` to ensure no
`resource` entries in the `grails-plugin.xml`; and then also a `jar`
block to exclude the classes from the final JAR.

**Testing**

After doing a `./gradlew jar` and making sure that the classes were not in the JAR and no mentions in `META-INF/grails-plugin.xml`, I did a `./gradlew install` and tested in my test app. All still worked, and on inspecting the schema of a file based H2 instance, confirmed the additional tables were no longer being created.