### PR TITLE
Fix saml.active flag

### DIFF
--- a/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
+++ b/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
@@ -77,16 +77,8 @@ class SpringSecuritySamlGrailsPlugin extends Plugin {
     Closure doWithSpring() {
         {->
             def conf = SpringSecurityUtils.securityConfig
-            if( !conf ) {
-                println 'There is no Spring Security config, SAML plugin will not be available.'
-
+            if( !isActive( conf ) )
                 return
-            }
-            else if( !conf.saml.active ) {
-                println 'saml.active is not true, SAML plugin will not be available.'
-
-                return
-            }
 
             println 'Configuring Spring Security SAML ...'
 
@@ -403,5 +395,28 @@ class SpringSecuritySamlGrailsPlugin extends Plugin {
 
     void onShutdown(Map<String, Object> event) {
         // TODO Implement code that is executed when the application shuts down (optional)
+    }
+
+    private static boolean isActive( def conf ) {
+        final PLUGIN_NOT_AVAILABLE = 'SAML plugin will not be available'
+        if( !conf ) {
+            // This is unlikely to ever occur due to default configs included in plugins,
+            // but historically has always been checked, so keeping.
+            println "There is no Spring Security config, $PLUGIN_NOT_AVAILABLE."
+
+            return false
+        }
+        else if( !conf.active ) {
+            println "Spring Security Core plugin is not active, $PLUGIN_NOT_AVAILABLE."
+
+            return false
+        }
+        else if( !conf.saml.active ) {
+            println "saml.active is not true, $PLUGIN_NOT_AVAILABLE."
+
+            return false
+        }
+
+        true
     }
 }

--- a/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
+++ b/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
@@ -77,11 +77,16 @@ class SpringSecuritySamlGrailsPlugin extends Plugin {
     Closure doWithSpring() {
         {->
             def conf = SpringSecurityUtils.securityConfig
-            if (!conf || !conf.active) { return }
+            if( !conf ) {
+                println 'There is no Spring Security config, SAML plugin will not be available.'
 
-//            SpringSecurityUtils.loadSecondaryConfig 'DefaultSamlSecurityConfig'
-//            conf = SpringSecurityUtils.securityConfig
-//            if (!conf.saml.active) { return }
+                return
+            }
+            else if( !conf.saml.active ) {
+                println 'saml.active is not true, SAML plugin will not be available.'
+
+                return
+            }
 
             println 'Configuring Spring Security SAML ...'
 


### PR DESCRIPTION
Also remove commented out code - has been commented out since 'Initial
Commit'.

Broke the active check into one for `conf` and one for
`conf.saml.active` so as to provide greater feedback possibilities for
users. As it is, if the `!conf` situation arises, it would mean the
default config is also missing from the plugin - so maybe this is not
required, but kept it as per the original fix.

Based on original fix @ fd0150cd2ced1b7482e7907be46a2f21eb024e20

Issue: #33 

Tested manually in test app by first setting the flag to true - all still worked; then setting to false - plugin did not start (and therefore my other spring security config failed as expected); then tried removing all my spring security config, but as noted above then it falls back to defaults, so...