### PR TITLE
Implement UserDetails Initialisation with SAML Attributes

### DIFF
--- a/src/main/groovy/org/grails/plugin/springsecurity/saml/SamlUserDetails.groovy
+++ b/src/main/groovy/org/grails/plugin/springsecurity/saml/SamlUserDetails.groovy
@@ -26,7 +26,7 @@ class SamlUserDetails extends GrailsUser {
 
     def getProperty(String name) {
         def attribute = samlAttributes[name]
-        if(attribute && !hasProperty(name)) {
+        if(samlAttributes.containsKey(name) && !hasProperty(name)) {
             return attribute
         }
         return metaClass.getProperty(this, name)

--- a/src/main/groovy/org/grails/plugin/springsecurity/saml/SamlUserDetails.groovy
+++ b/src/main/groovy/org/grails/plugin/springsecurity/saml/SamlUserDetails.groovy
@@ -1,0 +1,34 @@
+package org.grails.plugin.springsecurity.saml
+
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+import grails.compiler.GrailsCompileStatic
+
+import grails.plugin.springsecurity.userdetails.GrailsUser
+import org.springframework.security.core.GrantedAuthority
+
+@GrailsCompileStatic
+@EqualsAndHashCode(includes='username')
+@ToString(includes='username', includeNames=true, includePackage=false)
+class SamlUserDetails extends GrailsUser {
+
+    private Map samlAttributes
+
+    SamlUserDetails(String username, String password, boolean enabled,
+                boolean accountNonExpired, boolean credentialsNonExpired,
+                boolean accountNonLocked,
+                Collection<GrantedAuthority> authorities,
+                id, Map samlAttributes) {
+        super(username, password, enabled, accountNonExpired,
+               credentialsNonExpired, accountNonLocked, authorities, id)
+        this.samlAttributes = samlAttributes
+    }
+
+    def getProperty(String name) {
+        def attribute = samlAttributes[name]
+        if(attribute && !hasProperty(name)) {
+            return attribute
+        }
+        return metaClass.getProperty(this, name)
+    }
+}

--- a/src/test/groovy/org/grails/plugin/springsecurity/saml/SamlUserDetailsSpec.groovy
+++ b/src/test/groovy/org/grails/plugin/springsecurity/saml/SamlUserDetailsSpec.groovy
@@ -54,4 +54,24 @@ class SamlUserDetailsSpec extends Specification {
         then:
             thrown MissingPropertyException
     }
+
+    void "test access to a boolean saml attribute"() {
+        setup:
+            def user = new SamlUserDetails(username, password,
+                true, true, true, true, [],
+                username, [real: false])
+
+        expect:
+            user.real == false
+    }
+
+    void "test access to a null saml attribute"() {
+        setup:
+            def user = new SamlUserDetails(username, password,
+                true, true, true, true, [],
+                username, [organisation: null])
+
+        expect:
+            user.organisation == null
+    }
 }

--- a/src/test/groovy/org/grails/plugin/springsecurity/saml/SamlUserDetailsSpec.groovy
+++ b/src/test/groovy/org/grails/plugin/springsecurity/saml/SamlUserDetailsSpec.groovy
@@ -1,0 +1,57 @@
+package org.grails.plugin.springsecurity.saml
+
+import grails.test.mixin.*
+import grails.testing.web.controllers.ControllerUnitTest
+import spock.lang.Specification
+import groovy.lang.MissingPropertyException
+
+class SamlUserDetailsSpec extends Specification {
+
+    String username = "jackSparrow"
+    String password = "jackSparrow"
+    def emailAddress = "test@mailinator.com"
+    def firstname = "Jack"
+
+    void "test access to a saml attribute"() {
+        setup:
+            def user = new SamlUserDetails(username, password,
+                true, true, true, true, [],
+                username, [emailAddress: emailAddress, firstname: firstname])
+
+        expect:
+            user.emailAddress == emailAddress
+    }
+
+    void "test access to a normal attribute"() {
+        setup:
+            def user = new SamlUserDetails(username, password,
+                true, true, true, true, [],
+                username, [emailAddress: emailAddress, firstname: firstname])
+
+        expect:
+            user.username == username
+    }
+
+    void "test access to a normal attribute with a colliding saml attribute"() {
+        setup:
+            def user = new SamlUserDetails(username, password,
+                true, true, true, true, [],
+                username, [username: firstname])
+
+        expect: "the saml attribute will be ignored"
+            user.username != firstname
+            user.username == username
+    }
+
+    void "test access to an attribute that doesn't exist"() {
+        setup:
+            def user = new SamlUserDetails(username, password,
+                true, true, true, true, [],
+                username, [emailAddress: emailAddress])
+        when:
+            def value = user.firstname
+
+        then:
+            thrown MissingPropertyException
+    }
+}

--- a/src/test/groovy/org/grails/plugin/springsecurity/saml/SpringSamlUserDetailsServiceSpec.groovy
+++ b/src/test/groovy/org/grails/plugin/springsecurity/saml/SpringSamlUserDetailsServiceSpec.groovy
@@ -196,6 +196,24 @@ class SpringSamlUserDetailsServiceSpec  extends Specification implements Service
             samlUser == null
     }
 
+    void "loadUserBySAML should use default attributes on the user details if they are missing from the saml response"() {
+        given:
+            def emailAddress = "test@mailinator.com"
+            def firstname = "Jack"
+            service.samlAutoCreateActive = false
+            service.samlAutoCreateKey = 'username'
+
+            service.samlUserAttributeMappings = [email: "$MAIL_ATTR_NAME", firstName: "$FIRSTNAME_ATTR_NAME"]
+            setMockSamlAttributes(credential, ["$USERNAME_ATTR_NAME": username, "$MAIL_ATTR_NAME": emailAddress])
+
+        when:
+            def user = service.loadUserBySAML(credential)
+            def samlUser = TestSamlUser.findByUsername(username)
+        then: "no missing property exception will occur"
+            user.email == emailAddress
+            user.firstName == null
+    }
+
     void "loadUserBySAML should not persist a user that already exists"() {
         given:
             service.samlAutoCreateActive = true

--- a/src/test/groovy/org/grails/plugin/springsecurity/saml/SpringSamlUserDetailsServiceSpec.groovy
+++ b/src/test/groovy/org/grails/plugin/springsecurity/saml/SpringSamlUserDetailsServiceSpec.groovy
@@ -72,7 +72,7 @@ class SpringSamlUserDetailsServiceSpec  extends Specification implements Service
             def user = service.loadUserBySAML(credential)
 
         expect:
-            user instanceof GrailsUser
+            user instanceof SamlUserDetails
     }
 
     void "loadUserBySAML should return NameID as the username when no mapping specified"() {
@@ -156,6 +156,45 @@ class SpringSamlUserDetailsServiceSpec  extends Specification implements Service
             samlUser.firstName == firstname
     }
 
+    void "loadUserBySAML should set additional mapped attributes on the user and pass them on to the user details"() {
+        given:
+            def emailAddress = "test@mailinator.com"
+            def firstname = "Jack"
+            service.samlAutoCreateActive = true
+            service.samlAutoCreateKey = 'username'
+
+            service.samlUserAttributeMappings = [email: "$MAIL_ATTR_NAME", firstName: "$FIRSTNAME_ATTR_NAME"]
+            setMockSamlAttributes(credential, ["$USERNAME_ATTR_NAME": username, "$MAIL_ATTR_NAME": emailAddress, "$FIRSTNAME_ATTR_NAME": firstname])
+
+        when:
+            def user = service.loadUserBySAML(credential)
+            def samlUser = TestSamlUser.findByUsername(username)
+
+        then:
+            samlUser.email == emailAddress
+            samlUser.firstName == firstname
+            user.email == samlUser.email
+            user.firstName == samlUser.firstName
+    }
+
+    void "loadUserBySAML should set additional mapped attributes on the user details without saving the user"() {
+        given:
+            def emailAddress = "test@mailinator.com"
+            def firstname = "Jack"
+            service.samlAutoCreateActive = false
+            service.samlAutoCreateKey = 'username'
+
+            service.samlUserAttributeMappings = [email: "$MAIL_ATTR_NAME", firstName: "$FIRSTNAME_ATTR_NAME"]
+            setMockSamlAttributes(credential, ["$USERNAME_ATTR_NAME": username, "$MAIL_ATTR_NAME": emailAddress, "$FIRSTNAME_ATTR_NAME": firstname])
+
+        when:
+            def user = service.loadUserBySAML(credential)
+            def samlUser = TestSamlUser.findByUsername(username)
+        then:
+            user.email == emailAddress
+            user.firstName == firstname
+            samlUser == null
+    }
 
     void "loadUserBySAML should not persist a user that already exists"() {
         given:


### PR DESCRIPTION
1. I have created a new class called SamlUserDetails which uses `getProperty` to make it possible to access the SAML attributes as if they were defined manually via a user customised UserDetails class.
2. SpringSamlUserDetailsService now returns an instance of this class and populates it with the same attributes that were assigned to the User class.

I have added a few new test cases to the unit tests but I haven't tested this code on a real IDP so far. I'm especially concerned with missing saml attributes causing a missing property exception because this is a pain point that I've only noticed after uploading the first commit. We have some user specific saml attributes that are not available for all users so an access to e.g. `principal.institute` for someone who is not assigned to an institute should return null rather than crash with an exception.

Issue: https://github.com/jeffwils/grails-spring-security-saml/issues/31