### PR TITLE
Implement UTF8 support for metadata url

### DIFF
--- a/src/main/groovy/org/grails/plugin/springsecurity/saml/MetadataDisplayFilterUTF8.groovy
+++ b/src/main/groovy/org/grails/plugin/springsecurity/saml/MetadataDisplayFilterUTF8.groovy
@@ -1,0 +1,18 @@
+package org.grails.plugin.springsecurity.saml
+
+import org.springframework.security.saml.metadata.MetadataDisplayFilter
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import javax.servlet.ServletException
+import java.io.IOException
+import groovy.transform.CompileStatic
+import javax.servlet.ServletResponseWrapper
+
+@CompileStatic
+class MetadataDisplayFilterUTF8 extends MetadataDisplayFilter {
+    @Override
+    protected void processMetadataDisplay(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+        response.setCharacterEncoding("UTF-8")
+        super.processMetadataDisplay(request,response)
+    }
+}

--- a/src/main/groovy/org/grails/plugin/springsecurity/saml/MetadataDisplayFilterUTF8.groovy
+++ b/src/main/groovy/org/grails/plugin/springsecurity/saml/MetadataDisplayFilterUTF8.groovy
@@ -12,6 +12,11 @@ import javax.servlet.ServletResponseWrapper
 class MetadataDisplayFilterUTF8 extends MetadataDisplayFilter {
     @Override
     protected void processMetadataDisplay(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+        // The current version of Spring Security SAML (1.02)
+        // does not use UTF-8 by default
+        // This workaround is no longer necessary when
+        // Spring Security SAML 1.04 is released because
+        // it uses UTF-8 by default
         response.setCharacterEncoding("UTF-8")
         super.processMetadataDisplay(request,response)
     }

--- a/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
+++ b/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
@@ -129,7 +129,7 @@ class SpringSecuritySamlGrailsPlugin extends Plugin {
                 includeScoping = false
             }
 
-            metadataFilter(MetadataDisplayFilter) {
+            metadataFilter(MetadataDisplayFilterUTF8) {
                 filterProcessesUrl = conf.saml.metadata.url 						// '/saml/metadata'
             }
 


### PR DESCRIPTION
You can confirm that the change works with
```
curl -D - localhost:8080/saml/metadata
...
Content-Type: application/samlmetadata+xml;charset=UTF-8
```

Issue: https://github.com/jeffwils/grails-spring-security-saml/issues/16