### PR TITLE
Feature/43 - Use Local Roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 This plugin provides SAML 2.0 support for Grails 3 applications.  It was originally built from the Plugin that supported Grails 2 applications.  It enables SAML configuration directly from your application.yml or application.groovy without having to manually configure the Spring SAML Plugin and Grails Spring Security Plugin
 
 ### Plugin Compatibility with Grails
-Grails 3.0.x - Use Version 3.0.x of the plugin
-Grails 3.1.x - Use Version 3.1.x of the plugin
-Grails 3.3.x - Use Version 3.3.x of the plugin
+
+* Grails 3.0.x - Use Version 3.0.x of the plugin
+* Grails 3.1.x - Use Version 3.1.x of the plugin
+* Grails 3.3.x - Use Version 3.3.x of the plugin
 
 ### Installation
 **Maven**

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ grails:
 ```
 
 #### Property Table
-All of these properties can be put in either application.yml or application.groovy and they are all prefixed with:
+
+All of these properties can be put in either `application.yml` or `application.groovy` and they are all prefixed with:
 **grails.plugins.springsecurity.saml**
 
 
@@ -87,6 +88,7 @@ All of these properties can be put in either application.yml or application.groo
 | userAttributeMappings | Map | [username:'funkyUserNameFromIDP'] | Allows Custom Mapping if both Application and IDP Attribute Names cannot be changed. |
 | userGroupAttribute | String Value | 'memberOf' | Corresponds to the Role Designator in the SAML Assertion from the IDP |
 | userGroupToRoleMapping | Map [Spring Security Role: Saml Assertion Role] | [ROLE_MY_APP_ROLE: 'CN=MYSAMLGROUP, OU=MyAppGroups, DC=myldap, DC=example, DC=com'] | This maps the Spring Security Roles in your application to the roles from the SAML Assertion.  Only roles in this Map will be resolved. |
+| useLocalRoles | boolean | true | Determine a user's role based on the existing values in the local Spring Security tables. Will merge with additional roles loaded via `userGroupAttribute` and `userGroupToRoleMapping`. Defaults to `false`.
 | autoCreate.active | boolean | false | If you want the plugin to generate users in the DB as they are authenticated via SAML
 | autoCreate.key | domain class unique identifier | 'id' | if autoCreate active is true then this is the unique id field of the db table |
 | autoCreate.assignAuthorities | boolean | false | If you want the plugin to insert the authorities that come from the SAML message into the UserRole Table. |

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -61,7 +61,6 @@ grails:
                   usernamePropertyName: 'username'
                   enabledPropertyName: 'enabled'
                   passwordPropertyName: 'password'
-                  authoritiesPropertyName: 'roles'
                   authorityJoinClassName: 'test.TestUserRole'
             requestMap:
                   className: 'test/TestRequestmap'
@@ -69,7 +68,6 @@ grails:
                   configAttributeField: 'rolePattern'
             authority:
                   className: 'test.testRole'
-                  nameField: 'auth'
             saml:
                   userAttributeMappings:
                       username: 'username'

--- a/grails-app/services/org/grails/plugin/springsecurity/saml/SpringSamlUserDetailsService.groovy
+++ b/grails-app/services/org/grails/plugin/springsecurity/saml/SpringSamlUserDetailsService.groovy
@@ -127,7 +127,7 @@ class SpringSamlUserDetailsService extends GormUserDetailsService implements SAM
         if( samlUseLocalRoles ) {
             logger.debug( 'Using role assignments from local database.' )
 
-            def user = userClass.get( username )
+            def user = userClass.findByUsername( username )
             if( user ) {
                 loadAuthorities( user, username, true ).each { authority ->
                     authorities.add( authority )

--- a/src/integration-test/groovy/org/grails/plugin/springsecurity/saml/SpringSamlUserDetailsServiceIntegrationSpec.groovy
+++ b/src/integration-test/groovy/org/grails/plugin/springsecurity/saml/SpringSamlUserDetailsServiceIntegrationSpec.groovy
@@ -2,6 +2,7 @@ package org.grails.plugin.springsecurity.saml
 
 import grails.testing.mixin.integration.Integration
 import grails.transaction.Rollback
+import org.springframework.security.core.userdetails.UserDetails
 import spock.lang.Specification
 import test.TestUserRole
 import test.TestSamlUser
@@ -15,16 +16,21 @@ import grails.core.GrailsApplication
 @Rollback
 class SpringSamlUserDetailsServiceIntegrationSpec extends Specification {
 
-    String username = "jackSparrow"
-
     GrailsApplication grailsApplication
+
+    private final String testUsername = 'jackSparrow'
+    private final String testEmail = 'bob@fake.com'
+    private final String testPassword = 'test'
+    private final String userDomainClassName = "test.TestSamlUser"
+    private final String authorityNameField = 'authority'
+    private String authorityJoinClassName = 'test.TestUserRole'
 
     def "Test getting user details from db"() {
         given:
             TestSamlUser user = new TestSamlUser(
-                    username:username,
-                    email:'bob@fake.com',
-                    password: 'test'
+                    username: testUsername,
+                    email:    testEmail,
+                    password: testPassword
             ).save( failOnError: true )
             TestRole role = new TestRole(authority:"testauth").save( failOnError: true )
             TestUserRole.create( user,  role )
@@ -32,27 +38,61 @@ class SpringSamlUserDetailsServiceIntegrationSpec extends Specification {
             SpringSamlUserDetailsService service = new SpringSamlUserDetailsService(
                     samlAutoAssignAuthorities: false,
                     samlAutoCreateActive: true,
-                    userDomainClassName: "test.TestSamlUser",
+                    userDomainClassName: userDomainClassName,
                     samlAutoCreateKey: 'username',
-                    authorityNameField: 'authority',
-                    authorityJoinClassName: 'test.TestUserRole')
+                    authorityNameField: authorityNameField,
+                    authorityJoinClassName: authorityJoinClassName)
             service.grailsApplication = grailsApplication
 
         when:
-            SAMLCredential cred
-            cred = new SAMLCredential(
-                    new NameIDImpl("", "", ""),
-                    new AssertionImpl("", "", ""),
-                    null,
-                    null)
-            cred.metaClass.getNameID = { [value: "$username"] }
-            def loadedUser = service.loadUserBySAML(cred)
+            UserDetails loadedUser = (UserDetails)service.loadUserBySAML( buildSamlCredential( testUsername ) )
 
         then:
-            user.username == username
-            user.email == 'bob@fake.com'
+            user.username == testUsername
+            user.email == testEmail
             loadedUser
-            loadedUser.username == username
+            loadedUser.username == testUsername
     }
 
+    def 'Test retrieval of user roles from local DB'() {
+        given: 'A user with some roles and configuration to use local roles'
+            TestSamlUser user = new TestSamlUser(
+                    username: testUsername,
+                    email: testEmail,
+                    password: testPassword
+            ).save( failOnError: true )
+            ['role1', 'role2', 'role3', 'role4'].each { roleName ->
+                def role = new TestRole( authority: roleName ).save( failOnError: true )
+                TestUserRole.create( user, role )
+            }
+            SpringSamlUserDetailsService service = new SpringSamlUserDetailsService(
+                    samlUseLocalRoles:         true, // the key configuration param
+                    samlAutoAssignAuthorities: false,
+                    samlAutoCreateActive:      false,
+                    userDomainClassName:       userDomainClassName,
+                    authorityNameField:        authorityNameField,
+                    authorityJoinClassName:    authorityJoinClassName )
+            service.grailsApplication = grailsApplication
+
+        when: 'We attempt to retrieve the user based on SAML Credentials'
+            UserDetails loadedUser = (UserDetails)service.loadUserBySAML( buildSamlCredential( testUsername ) )
+            def loadedRoles = TestSamlUser.findByUsername( testUsername ).authorities
+
+        then: 'the user is returned with roles which match their DB roles'
+            loadedUser.username == testUsername
+            loadedUser.authorities.size() == loadedRoles.size()
+            loadedUser.authorities*.authority.containsAll( loadedRoles*.authority )
+    }
+
+    private static SAMLCredential buildSamlCredential(String username ) {
+        SAMLCredential cred
+        cred = new SAMLCredential(
+                new NameIDImpl("", "", ""),
+                new AssertionImpl("", "", ""),
+                null,
+                null)
+        cred.metaClass.getNameID = { [value: "$username"] }
+
+        cred
+    }
 }


### PR DESCRIPTION
Added new configuration value `saml.useLocalRoles` and backing logic.

In doing so undertook a minor refactor to increase readability and maintainability.

Added doco for basic usage in `README.md` - and also did a minor other bit of tidy up in there.

Tested with the supplied integration spec (and confirming existing suite still works with `./graldew check`), as well as manual testing in my current project which requires this method of role resolution.

Issue: #43 