### PR TITLE
Remove userDetailsService from SamlSecurityService

### DIFF
--- a/grails-app/conf/plugin.yml
+++ b/grails-app/conf/plugin.yml
@@ -3,7 +3,7 @@ grails:
         springsecurity:
             saml:
                 userAttributeMappings: {}
-                active: true
+                active: false
                 afterLoginUrl: '/'
                 afterLogoutUrl: '/'
                 userGroupAttribute: 'memberOf'

--- a/grails-app/services/org/grails/plugin/springsecurity/saml/SamlSecurityService.groovy
+++ b/grails-app/services/org/grails/plugin/springsecurity/saml/SamlSecurityService.groovy
@@ -12,18 +12,9 @@ import groovy.util.logging.Slf4j
  */
 @Slf4j('logger')
 class SamlSecurityService extends SpringSecurityService {
-    SpringSamlUserDetailsService userDetailsService
     def userCache
     static transactional = false
     def config
-
-    SpringSamlUserDetailsService getUserDetailsService() {
-        return userDetailsService
-    }
-
-    void setUserDetailsService(SpringSamlUserDetailsService userDetailsService) {
-        this.userDetailsService = userDetailsService
-    }
 
     Object getCurrentUser() {
         logger.debug("SamlSecurityService getCurrentUser")

--- a/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
+++ b/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
@@ -375,7 +375,7 @@ class SpringSecuritySamlGrailsPlugin extends Plugin {
                 grailsApplication = grailsApplication //(GrailsApplication)ref('grailsApplication')
                 passwordEncoder = ref('passwordEncoder')
                 objectDefinitionSource = ref('objectDefinitionSource')
-                userDetailsService = ref('userDetailsService')
+                //userDetailsService = ref('userDetailsService')
                 userCache = ref('userCache')
             }
 


### PR DESCRIPTION
I have removed userDetailsService from SamlSecurityService because it is no longer used and can cause the plugin to crash on startup. See issue #49

I could successfully login via irstevenson's grails-spring-security-saml-test app and also have successfully deployed it to my staging system without any problems.