### PR TITLE
 Exclude example metadata and keystore from build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,4 +147,8 @@ task wrapper(type: Wrapper) {
 
 jar {
     exclude 'test/**'
+    exclude 'security/keystore.jks'
+    exclude 'security/sp.xml'
+    exclude 'security/idp-local.xml'
+    exclude 'saml/test.xml'
 }

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -81,7 +81,7 @@ grails:
                        key: 'username'
                        assignAuthorities: true
                   metadata:
-                       defaultIdp: 'ping'
+                       defaultIdp: 'localhost:default:entityId'
                        url: '/saml/metadata'
                        providers:
                            ping: 'security/idp-local.xml'

--- a/grails-app/conf/plugin.yml
+++ b/grails-app/conf/plugin.yml
@@ -14,10 +14,9 @@ grails:
                     assignAuthorities: true
                 metadata:
                     timeout: 5000
-                    defaultIdp: 'ping'
+                    defaultIdp: ''
                     url: '/saml/metadata'
-                    providers:
-                        ping: 'security/idp-local.xml'
+                    providers: {}
                     sp:
                         file: 'security/sp.xml'
                         defaults:

--- a/index.md
+++ b/index.md
@@ -65,7 +65,7 @@ All of these properties can be put in either `application.yml` or `application.g
 | autoCreate.key | domain class unique identifier | 'id' | if autoCreate active is true then this is the unique id field of the db table |
 | autoCreate.assignAuthorities | boolean | false | If you want the plugin to insert the authorities that come from the SAML message into the UserRole Table. |
 | metadata.providers | Map [idp alias: idp file reference] | [ping:"/pathtoIdpFile/myIdp.xml"] | Map of idp providers. Contain an alias and reference to the idp xml file |
-| metadata.defaultIdp | String | 'ping' | the entityId of the default Idp from the ones listed in the metadata.provider map |
+| metadata.defaultIdp | String | 'https://idp.example.org/idp/shibboleth' | the entityId of the default Idp from the ones listed in the metadata.provider map. If no entityId is given an IDP will be picked from the list automatically. |
 | metadata.url | relative url | '/saml/metadata' | url used to retrieve the SP metadata for your app to send to the IDP |
 | metadata.sp.file | file reference as string | "/mySpFilePath/myspfile.xml" | Reference to your SP XML File.  This can be on the classpath or in your file system. |
 | metadata.sp.defaults.local | boolean | true | True for metadata of a local service provider. False for remote identity providers. |
@@ -296,7 +296,7 @@ grails.plugin.springsecurity.saml.userGroupAttribute = 'roles'
 grails.plugin.springsecurity.saml.autoCreate.active = false  //If you want the plugin to generate users in the DB as they are authenticated via SAML
 grails.plugin.springsecurity.saml.autoCreate.key = 'id'
 grails.plugin.springsecurity.saml.autoCreate.assignAuthorities=false  //If you want the plugin to assign the authorities that come from the SAML message.
-grails.plugin.springsecurity.saml.metadata.defaultldp = 'ping'
+grails.plugin.springsecurity.saml.metadata.defaultIdp = 'localhost:default:entityId'
 grails.plugin.springsecurity.saml.metadata.url = '/saml/metadata'
 grails.plugin.springsecurity.saml.metadata.providers = [ping:'security/idp-local.xml']
 grails.plugin.springsecurity.saml.metadata.sp.file = "security/sp.xml"
@@ -367,7 +367,7 @@ grails:
                key: 'id'
                assignAuthorities: false  //If you want the plugin to assign the authorities that come from the SAML message.
             metadata:
-               defaultldp: 'ping'
+               defaultIdp: 'localhost:default:entityId'
                url: '/saml/metadata'
                providers: [ping:'security/idp-local.xml']
                sp:

--- a/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
+++ b/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
@@ -265,8 +265,9 @@ class SpringSecuritySamlGrailsPlugin extends Plugin {
                         hostedSPName = defaultSpConfig?."alias"
                     }
                 }
-
-                defaultIDP = conf.saml.metadata?.defaultIdp
+                if(conf.saml.metadata?.defaultIdp != '') {
+                    defaultIDP = conf.saml.metadata?.defaultIdp
+                }
             }
 
 

--- a/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
+++ b/src/main/groovy/org/grails/plugin/springsecurity/saml/SpringSecuritySamlGrailsPlugin.groovy
@@ -111,8 +111,7 @@ class SpringSecuritySamlGrailsPlugin extends Plugin {
 
             SAMLLogger(SAMLDefaultLogger)
 
-
-            if(!new File(conf.saml.keyManager.storeFile).exists() || !new ClassPathResource(conf.saml.keyManager.storeFile).exists()) {
+            if(!getResource(conf.saml.keyManager.storeFile).exists()) {
                 throw new IOException("Keystore cannot be loaded from file '${conf.saml.keyManager.storeFile}'. " +
                          "Please check that the path configured in " +
                          "'grails.plugin.springsecurity.saml.keyManager.storeFile' in your application.yml is correct.")


### PR DESCRIPTION
The files were excluded via the jar section in build.gradle. Furthermore file checks were added to inform the user that the file is missing and which setting in the application.yml must be configured to fix the error.

I have used the following commands to confirm that the jar file does not contain the undesired files.

```bash
unzip -l build/libs/spring-security-saml-3.3.1-SNAPSHOT.jar | grep .xml
unzip -l build/libs/spring-security-saml-3.3.1-SNAPSHOT.jar | grep .jks
```

